### PR TITLE
Remove unnecessary postinstall script

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,6 @@
     "test": "test"
   },
   "scripts": {
-    "postinstall": "bower install",
     "test": "gulp test"
   },
   "repository": {


### PR DESCRIPTION
This breaks installs via NPM. It expects bower to be installed, but bower is deprecated. Also it is only needed if you develop this package, but not for people who use it as a dependency.

Thanks